### PR TITLE
update yt dl path to be an ID

### DIFF
--- a/routes/v1/media/download.py
+++ b/routes/v1/media/download.py
@@ -88,7 +88,7 @@ def download_media(job_id, data):
             # Configure yt-dlp options
             ydl_opts = {
                 'format': 'best',  # Download best quality
-                'outtmpl': os.path.join(temp_dir, '%(title)s.%(ext)s'),
+                'outtmpl': os.path.join(temp_dir, '%(id)s.%(ext)s'),
                 'quiet': True,
                 'no_warnings': True,
             }


### PR DESCRIPTION
change the path for yout dl to be an ID instead of a character path to get around titles with special characters